### PR TITLE
Setup database and migrate using the Deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ VERIFICATION_SECRET_KEY: The secret key for email or user verification.
 
 ### Backend Deployment
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fandersonresende%2Fnextjs-fastapi-template-deploy%2Ftree%2Fmain%2Ffastapi_backend&env=CORS_ORIGINS,ACCESS_SECRET_KEY,RESET_PASSWORD_SECRET_KEY,VERIFICATION_SECRET_KEY&stores=%5B%7B%22type%22%3A%22postgres%22%7D%5D)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvintasoftware%2Fnextjs-fastapi-template%2Ftree%2Fmain%2Ffastapi_backend&env=CORS_ORIGINS,ACCESS_SECRET_KEY,RESET_PASSWORD_SECRET_KEY,VERIFICATION_SECRET_KEY&stores=%5B%7B%22type%22%3A%22postgres%22%7D%5D)
 
 1. **Deploying the Backend**  
    - Click the **Backend** button above to begin deployment.

--- a/README.md
+++ b/README.md
@@ -337,33 +337,28 @@ VERIFICATION_SECRET_KEY: The secret key for email or user verification.
 
 1. **Deploying the Backend**  
    - Click the **Backend** button above to begin deployment.
+   - Set up the database first. The connection is automatically configured, so just follow the steps, and it should work by default.
    - During the deployment process, you will be prompted to configure the following environment variables:
 
      - **CORS_ORIGINS**  
        - Set this to `["*"]` initially to allow all origins. You will update this with the frontend URL later.
-
-     - **DATABASE_URL**  
-       - Use a placeholder value (e.g., `https://`) if you don't yet have the actual database URL. Replace it with the correct URL post-deployment.
 
      - **ACCESS_SECRET_KEY**, **RESET_PASSWORD_SECRET_KEY**, **VERIFICATION_SECRET_KEY**  
        - You can temporarily set these secret keys as plain strings (e.g., `examplekey`) during deployment. However, you should generate secure keys and update them after the deployment in the **Post-Deployment Configuration** section.
 
    - Complete the deployment process.
 
-2. **Post-Deployment Configuration**  
+2. **Post-Deployment Configuration**
    - Access the **Settings** page of the deployed backend project.  
    - Navigate to the **Environment Variables** section and update the following variables with secure values:
 
      - **CORS_ORIGINS**  
        - Once the frontend is deployed, replace `["*"]` with the actual frontend URL.
 
-     - **DATABASE_URL**  
-       - Update this with the actual database URL if not set during deployment.
-
      - **ACCESS_SECRET_KEY**  
        - Generate a secure key for API access and set it here.  
 
-     - **RESET_PASSWORD_SECRET_KEY**  
+     - **RESET_PASSWORD_SECRET_KEY**
        - Generate a secure key for password reset functionality and set it.
 
      - **VERIFICATION_SECRET_KEY**  
@@ -383,10 +378,9 @@ VERIFICATION_SECRET_KEY: The secret key for email or user verification.
    3. **Configuring the Database URL**
       - After creating the database, retrieve the **Database URL** provided by Neon.  
       - Include this URL in your **Environment Variables** under `DATABASE_URL`.  
-      - Replace `postgres` with `postgres+asyncpg` at the start of the URL to ensure compatibility with asynchronous database operations.
 
    4. **Migrating the Database**
-      - Once the database URL is configured, run your database migration script. This step is essential for creating the necessary tables and initializing your database schema.
+      - The database migration will happen automatically during the deployment GitHub action, setting up the necessary tables and schema.
 
 
 ## Makefile

--- a/README.md
+++ b/README.md
@@ -333,10 +333,10 @@ VERIFICATION_SECRET_KEY: The secret key for email or user verification.
 
 ### Backend Deployment
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvintasoftware%2Fnextjs-fastapi-template%2Ftree%2Fmain%2Ffastapi_backend&env=CORS_ORIGINS,TEST_DATABASE_URL,DATABASE_URL,ACCESS_SECRET_KEY,RESET_PASSWORD_SECRET_KEY,VERIFICATION_SECRET_KEY)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fandersonresende%2Fnextjs-fastapi-template-deploy%2Ftree%2Fmain%2Ffastapi_backend&env=CORS_ORIGINS,ACCESS_SECRET_KEY,RESET_PASSWORD_SECRET_KEY,VERIFICATION_SECRET_KEY&stores=%5B%7B%22type%22%3A%22postgres%22%7D%5D)
 
 1. **Deploying the Backend**  
-   - Click the **Backend** button above to begin deployment.  
+   - Click the **Backend** button above to begin deployment.
    - During the deployment process, you will be prompted to configure the following environment variables:
 
      - **CORS_ORIGINS**  

--- a/fastapi_backend/alembic_migrations/env.py
+++ b/fastapi_backend/alembic_migrations/env.py
@@ -40,15 +40,15 @@ database_url = os.getenv("DATABASE_URL")
 if not database_url:
     raise ValueError("DATABASE_URL environment variable is not set!")
 
-tmpPostgres = urlparse(database_url)
+parsed_db_url = urlparse(database_url)
 
-formated_database_url = (
-    f"postgresql+asyncpg://{tmpPostgres.username}:{tmpPostgres.password}@"
-    f"{tmpPostgres.hostname}{':' + str(tmpPostgres.port) if tmpPostgres.port else ''}"
-    f"{tmpPostgres.path}"
+async_db_connection_url = (
+    f"postgresql+asyncpg://{parsed_db_url.username}:{parsed_db_url.password}@"
+    f"{parsed_db_url.hostname}{':' + str(parsed_db_url.port) if parsed_db_url.port else ''}"
+    f"{parsed_db_url.path}"
 )
 
-config.set_main_option("sqlalchemy.url", formated_database_url)
+config.set_main_option("sqlalchemy.url", async_db_connection_url)
 
 
 def run_migrations_offline() -> None:

--- a/fastapi_backend/alembic_migrations/env.py
+++ b/fastapi_backend/alembic_migrations/env.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from urllib.parse import urlparse
 
 from logging.config import fileConfig
 
@@ -35,10 +36,19 @@ target_metadata = Base.metadata
 # Retrieve the database URL from the environment
 # set it during execution
 database_url = os.getenv("DATABASE_URL")
+
 if not database_url:
     raise ValueError("DATABASE_URL environment variable is not set!")
 
-config.set_main_option("sqlalchemy.url", database_url)
+tmpPostgres = urlparse(database_url)
+
+formated_database_url = (
+    f"postgresql+asyncpg://{tmpPostgres.username}:{tmpPostgres.password}@"
+    f"{tmpPostgres.hostname}{':' + str(tmpPostgres.port) if tmpPostgres.port else ''}"
+    f"{tmpPostgres.path}"
+)
+
+config.set_main_option("sqlalchemy.url", formated_database_url)
 
 
 def run_migrations_offline() -> None:

--- a/fastapi_backend/app/config.py
+++ b/fastapi_backend/app/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
 
     # Database
     DATABASE_URL: str
-    TEST_DATABASE_URL: str = None
+    TEST_DATABASE_URL: str | None = None
     EXPIRE_ON_COMMIT: bool = False
 
     # User

--- a/fastapi_backend/app/database.py
+++ b/fastapi_backend/app/database.py
@@ -9,16 +9,17 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from .config import settings
 from .models import Base, User
 
-tmpPostgres = urlparse(settings.DATABASE_URL)
 
-formated_database_url = (
-    f"postgresql+asyncpg://{tmpPostgres.username}:{tmpPostgres.password}@"
-    f"{tmpPostgres.hostname}{':' + str(tmpPostgres.port) if tmpPostgres.port else ''}"
-    f"{tmpPostgres.path}"
+parsed_db_url = urlparse(settings.DATABASE_URL)
+
+async_db_connection_url = (
+    f"postgresql+asyncpg://{parsed_db_url.username}:{parsed_db_url.password}@"
+    f"{parsed_db_url.hostname}{':' + str(parsed_db_url.port) if parsed_db_url.port else ''}"
+    f"{parsed_db_url.path}"
 )
 
 # Disable connection pooling for serverless environments like Vercel
-engine = create_async_engine(formated_database_url, poolclass=NullPool)
+engine = create_async_engine(async_db_connection_url, poolclass=NullPool)
 
 async_session_maker = async_sessionmaker(
     engine, expire_on_commit=settings.EXPIRE_ON_COMMIT

--- a/fastapi_backend/app/database.py
+++ b/fastapi_backend/app/database.py
@@ -1,4 +1,5 @@
 from typing import AsyncGenerator
+from urllib.parse import urlparse
 
 from fastapi import Depends
 from fastapi_users.db import SQLAlchemyUserDatabase
@@ -8,8 +9,16 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from .config import settings
 from .models import Base, User
 
+tmpPostgres = urlparse(settings.DATABASE_URL)
+
+formated_database_url = (
+    f"postgresql+asyncpg://{tmpPostgres.username}:{tmpPostgres.password}@"
+    f"{tmpPostgres.hostname}{':' + str(tmpPostgres.port) if tmpPostgres.port else ''}"
+    f"{tmpPostgres.path}"
+)
+
 # Disable connection pooling for serverless environments like Vercel
-engine = create_async_engine(settings.DATABASE_URL, poolclass=NullPool)
+engine = create_async_engine(formated_database_url, poolclass=NullPool)
 
 async_session_maker = async_sessionmaker(
     engine, expire_on_commit=settings.EXPIRE_ON_COMMIT

--- a/fastapi_backend/vercel.json
+++ b/fastapi_backend/vercel.json
@@ -1,4 +1,11 @@
 {
+  "buildCommand": "python3 -m venv venv && . venv/bin/activate && pip install -r requirements.txt && alembic upgrade head && deactivate && rm -rf venv",
+  "outputDirectory": "api",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  },
   "routes": [
     {
       "src": "/(.*)",


### PR DESCRIPTION
1. This code improves the backend deploy button:
- The database is created in a few steps once you hit the deploy button
- The database url is configured to work both local and in production with the DATABASE_URL env included by vercel after creating the database
- I did a small hack to be used only when the deploy button is used, that should happen only once, to migrate the database. In the future with the github action deploy, I'll use other vercel.json file that can be set as an argument.

Then, we have two functional deploy buttons that leaves the application read to be proposed as a vercel template.

In the next PR, I am going to work on the github action to deploy, this will be used in a every day basis and how in fact the project should be used for development. At the end, Readme will be adjusted to convey this step.