### PR TITLE
Added `@eslint/eslintrc` to devDependency

### DIFF
--- a/nextjs-frontend/package.json
+++ b/nextjs-frontend/package.json
@@ -38,6 +38,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.18.0",
     "@hey-api/openapi-ts": "^0.60.1",
     "@next/eslint-plugin-next": "^15.1.4",

--- a/nextjs-frontend/pnpm-lock.yaml
+++ b/nextjs-frontend/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.1
+        version: 3.3.1
       '@eslint/js':
         specifier: ^9.18.0
         version: 9.18.0
@@ -364,8 +367,8 @@ packages:
     resolution: {integrity: sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.2.0':
-    resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/js@9.18.0':
@@ -4252,7 +4255,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.2.0':
+  '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
       debug: 4.3.7
@@ -6204,7 +6207,7 @@ snapshots:
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.19.1
       '@eslint/core': 0.10.0
-      '@eslint/eslintrc': 3.2.0
+      '@eslint/eslintrc': 3.3.1
       '@eslint/js': 9.18.0
       '@eslint/plugin-kit': 0.2.5
       '@humanfs/node': 0.16.6


### PR DESCRIPTION
PR fixes a bug where a fresh project setup would fail during the pre-commit lint check.

  **Changes**
   - Added @eslint/eslintrc to the devDependencies in nextjs-frontend/package.json.


  **Reason**
  The nextjs-frontend/eslint.config.mjs file imports { FlatCompat } from "@eslint/eslintrc", but this package was
  not listed as a dependency in devDependencies. This caused the pnpm run lint command and the pre-commit hook to fail with a "Cannot
  find package" error. Adding the dependency resolves this issue.

## Summary by Sourcery

Add the missing @eslint/eslintrc dependency to the Next.js frontend to restore successful lint and pre-commit checks

Bug Fixes:
- Add @eslint/eslintrc to devDependencies in package.json to resolve missing package errors during linting

Enhancements:
- Update pnpm-lock.yaml to bump @eslint/eslintrc to version 3.3.1