### PR TITLE
Release 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ frontend TypeScript client, `nextjs-frontend`.
     The backend and the frontend are versioned together, that is, they have the same version number.
     When you update the backend, you should also update the frontend to the same version.
 
+## 0.0.4 <small>July 9, 2025</small> {id="0.0.4"}
+
+- Fix ESlint missing for pre-commit
+
 ## 0.0.3 <small>April 23, 2025</small> {id="0.0.3"}
 
 - Created docs

--- a/fastapi_backend/pyproject.toml
+++ b/fastapi_backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "app"
-version = "0.0.3"
+version = "0.0.4"
 description = ""
 authors = [{ name = "Anderson Resende", email = "anderson@vinta.com.br" }]
 requires-python = ">=3.12,<3.13"

--- a/fastapi_backend/uv.lock
+++ b/fastapi_backend/uv.lock
@@ -49,7 +49,7 @@ wheels = [
 
 [[package]]
 name = "app"
-version = "0.0.3"
+version = "0.0.4"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/nextjs-frontend/package.json
+++ b/nextjs-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-frontend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary by Sourcery

Prepare release 0.0.4 by updating package versions, adding changelog entry, enabling ESLint in pre-commit, and refreshing the lock file.

Bug Fixes:
- Enable ESLint in pre-commit hooks

Documentation:
- Add changelog entry for version 0.0.4

Chores:
- Bump fastapi backend and nextjs frontend versions to 0.0.4
- Regenerate uv.lock file